### PR TITLE
Fixes for subtract in tofino statelss alu

### DIFF
--- a/chipc/templates/tofino_p4.j2
+++ b/chipc/templates/tofino_p4.j2
@@ -133,14 +133,12 @@ action {{sketch_name}}_stateless_alu_{{i}}_{{j}}_action () {
     {% elif opcode == 4 %}
     subtract({{result}}, {{operand0}}, {{operand1}});
     {% elif opcode == 5 %}
-    subtract({{result}}, {{operand0}}, {{immediate_operand}});
-    {% elif opcode == 6 %}
     subtract({{result}}, {{immediate_operand}}, {{operand0}});
-    {% elif opcode == 7 %}
+    {% elif opcode == 6 %}
     max({{result}}, {{operand0}}, {{operand1}});
-    {% elif opcode == 8 %}
+    {% elif opcode == 7 %}
     max({{result}}, {{operand0}}, {{immediate_operand}});
-    {% elif opcode == 9 %}
+    {% elif opcode == 8 %}
     min({{result}}, {{operand0}}, {{operand1}});
     {% else %}
     min({{result}}, {{operand0}}, {{immediate_operand}});

--- a/example_alus/stateless_alus/stateless_alu_for_tofino.alu
+++ b/example_alus/stateless_alus/stateless_alu_for_tofino.alu
@@ -1,4 +1,4 @@
-// Max value of opcode is 10
+// Max value of opcode is 9
 type : stateless
 state variables : {}
 hole variables : {opcode, immediate_operand}
@@ -23,18 +23,15 @@ if (opcode == 0) {
     // subtract(mdata.result1, mdata.pkt_0, mdata.pkt_1);
     return pkt_0 - pkt_1;
 } elif (opcode == 5) {
-    // subtract(mdata.result1, mdata.pkt_0, immediate_operand);
-    return pkt_0 - immediate_operand;
-} elif (opcode == 6) {
     // subtract(mdata.result1, immediate_operand, mdata.pkt_0);
     return immediate_operand - pkt_0;
-} elif (opcode == 7) {
+} elif (opcode == 6) {
     // max(mdata.result1, mdata.pkt_0, mdata.pkt_1);
     return pkt_0 > pkt_1 ? pkt_0 : pkt_1;
-} elif (opcode == 8) {
+} elif (opcode == 7) {
     // max(mdata.result1, mdata.pkt_0, immediate_operand);
     return pkt_0 > immediate_operand ? pkt_0 : immediate_operand;
-} elif (opcode == 9) {
+} elif (opcode == 8) {
     // min(mdata.result1, mdata.pkt_0, mdata.pkt_1);
     return pkt_0 > pkt_1 ? pkt_1 : pkt_0;
 } else {

--- a/example_alus/stateless_alus/stateless_alu_for_tofino.alu
+++ b/example_alus/stateless_alus/stateless_alu_for_tofino.alu
@@ -21,7 +21,7 @@ if (opcode == 0) {
     return pkt_0 + immediate_operand;
 } elif (opcode == 4) {
     // subtract(mdata.result1, mdata.pkt_0, mdata.pkt_1);
-    return pkt_1 - pkt_0;
+    return pkt_0 - pkt_1;
 } elif (opcode == 5) {
     // subtract(mdata.result1, mdata.pkt_0, immediate_operand);
     return pkt_0 - immediate_operand;


### PR DESCRIPTION
subtract(dst, src1, src2)
dst = src1 - src2
src2 can only be field or metadata.

Refer to tofino p4 14 manual.

