### PR TITLE
Tofino code generation bug fixes

### DIFF
--- a/chipc/templates/tofino_p4.j2
+++ b/chipc/templates/tofino_p4.j2
@@ -75,7 +75,7 @@ blackbox stateful_alu {{sketch_name}}_stateful_alu_{{i}}_{{j}}_blackbox {
     output_value              : {{alu['output_value_expr']}};
     output_dst                : {{alu['output_dst']}};
     {# TODO: Set initial values more sensibly. #}
-    initial_register_lo_value : 19; // Magic value TODO: needs to be changed.
+    initial_register_lo_value : 0; // Magic value TODO: needs to be changed.
     initial_register_hi_value : 0;
 
     {# Instructions omitted for now

--- a/chipc/templates/tofino_p4.j2
+++ b/chipc/templates/tofino_p4.j2
@@ -131,7 +131,7 @@ action {{sketch_name}}_stateless_alu_{{i}}_{{j}}_action () {
     {% elif opcode == 3 %}
     add({{result}}, {{operand0}}, {{immediate_operand}});
     {% elif opcode == 4 %}
-    subtract({{result}}, {{operand0}}, {{operand1}});
+    subtract({{result}}, {{operand1}}, {{operand0}});
     {% elif opcode == 5 %}
     subtract({{result}}, {{operand0}}, {{immediate_operand}});
     {% elif opcode == 6 %}

--- a/example_alus/stateless_alus/stateless_alu_for_tofino.alu
+++ b/example_alus/stateless_alus/stateless_alu_for_tofino.alu
@@ -20,7 +20,7 @@ if (opcode == 0) {
     // add(mdata.reseult1, mdata.pkt_0, immediate_operand);
     return pkt_0 + immediate_operand;
 } elif (opcode == 4) {
-    // subtract(mdata.result1, mdata.pkt_0, mdata.pkt_1);
+    // subtract(mdata.result1, mdata.pkt_1, mdata.pkt_0);
     return pkt_1 - pkt_0;
 } elif (opcode == 5) {
     // subtract(mdata.result1, mdata.pkt_0, immediate_operand);


### PR DESCRIPTION
This fixes a bug in how the hole-value assignments were being translated into P4 code for the subtract operation. It also sets a more sensible default for the initial value of state variables.